### PR TITLE
Link for mock.md corrected

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -24,7 +24,7 @@
                 <h1>Swagger Pet Store</h1>
 
                 <p>
-                    This sample API is powered by the <a href="https://github.com/BigstickCarpet/swagger-express-middleware/blob/master/docs/mock.md">Swagger Express Middleware mock</a>
+                    This sample API is powered by the <a href="https://github.com/BigstickCarpet/swagger-express-middleware/blob/master/docs/middleware/mock.md">Swagger Express Middleware mock</a>
                     in an otherwise empty Express application. There's no extra configuration, custom code, or third-party-middleware.
                 </p>
                 <p>


### PR DESCRIPTION
https://github.com/BigstickCarpet/swagger-express-middleware/blob/master/docs/middleware/mock.md
The middleware part was missing
